### PR TITLE
Add support for tap on mobile or mouse pointer to the frontend

### DIFF
--- a/static/src/js/game/GameScene.js
+++ b/static/src/js/game/GameScene.js
@@ -4,6 +4,7 @@ import { resizeImage } from '../utils/image-utils.js';
 export class GameScene extends Phaser.Scene {
     /** @type {GameState} */
     #gameState;
+    #lastPointerUp = false;
 
     /**
      * @param {GameState} gameState Game state instance
@@ -35,7 +36,7 @@ export class GameScene extends Phaser.Scene {
 
     create() {
         this.setupGame();
-        this.setupInput();
+        this.setupInputs();
         this.setupTimer();
     }
 
@@ -89,10 +90,27 @@ export class GameScene extends Phaser.Scene {
         );
     }
 
-    setupInput() {
-        this.#gameState.spaceKey = this.input.keyboard.addKey(
-            Phaser.Input.Keyboard.KeyCodes.SPACE
+    setupInputs() {
+        // Setup keyboard input
+        this.#gameState.spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+
+        // Setup pointer/touch input for the entire game area
+        const advanceArea = this.add.rectangle(
+            0,
+            0,
+            this.cameras.main.width,
+            this.cameras.main.height,
+            0x000000,
+            0  // Fully transparent
         );
+        advanceArea.setOrigin(0, 0);
+        advanceArea.setInteractive();
+
+        // Add pointer up event (works for both mouse click and touch)
+        // using the Phaser3 event handler this is way is not handled in update
+        advanceArea.on('pointerup', () => {
+            this.handleAdvanceGame();
+        });
     }
 
     setupTimer() {
@@ -113,14 +131,19 @@ export class GameScene extends Phaser.Scene {
     }
 
     update() {
-        const gameState  = this.#gameState;
+        // Check for keyboard input
+        if (Phaser.Input.Keyboard.JustDown(this.#gameState.spaceKey)) {
+            this.handleAdvanceGame();
+        }
+    }
 
-        if (Phaser.Input.Keyboard.JustDown(gameState.spaceKey)) {
-            if (!gameState.gameOver) {
-                this.handleGameStep();
-            } else if (!gameState.isFinalScreenDisplayed) {
-                this.showGameOver();
-            }
+    handleAdvanceGame() {
+        const gameState = this.#gameState;
+
+        if (!gameState.gameOver) {
+            this.handleGameStep();
+        } else if (!gameState.isFinalScreenDisplayed) {
+            this.showGameOver();
         }
     }
 


### PR DESCRIPTION
This is something I wanted to add for long time ago. I used Claude Sonnet 3.5 to help me and it got right on first tentative.

Here is the comments it made.

Yes, we can handle both keyboard and touch/pointer input in Phaser 3 to advance the game. Let me help you modify the GameScene to support both inputs.

Key changes made:

Created a new method `handleAdvanceGame()` that contains the logic previously in the `update()` method
Added a transparent, interactive rectangle that covers the entire game area
Set up pointer/touch input using Phaser's built-in input system
Maintained keyboard support for desktop users
Both input methods trigger the same game logic

The main changes are in the `setupInputs()` and `update()` methods. Now the game can be advanced by:

Pressing the space key on desktop
Tapping anywhere on the screen on mobile devices
Clicking anywhere on the screen with a mouse

The transparent rectangle covers the entire game area and captures all pointer events. It's invisible (opacity set to 0) so it won't interfere with the game's visuals.
To test this:

On desktop: both space key and mouse clicks should work
On mobile: tapping anywhere on the screen should advance the game
The game logic remains exactly the same, only the input handling has changed